### PR TITLE
Changing the pigz wget container

### DIFF
--- a/conf/containers.config
+++ b/conf/containers.config
@@ -44,7 +44,7 @@ process {
 
   withLabel:gnu_wget {
     conda     = (params.enable_conda ? "bioconda::gnu-wget=1.18" : null)
-    container = (!params.enable_conda ? "${params.depot_url}/gnu-wget:1.18--h7132678_6" : null)
+    container = (!params.enable_conda ? "${params.depot_url}/gnu-wget:1.18--h60da905_7" : null)
   }
   withLabel:fastqc {
     conda     = (params.enable_conda ? "bioconda::fastqc=0.11.7" : null)

--- a/conf/containers.config
+++ b/conf/containers.config
@@ -39,7 +39,13 @@ profiles {
 }
 
 process {
+
   //////// Single tool containers
+
+  withLabel:gnu_wget {
+    conda     = (params.enable_conda ? "bioconda::gnu-wget=1.18" : null)
+    container = (!params.enable_conda ? "${params.depot_url}/gnu-wget:1.18--h7132678_6" : null)
+  }
   withLabel:fastqc {
     conda     = (params.enable_conda ? "bioconda::fastqc=0.11.7" : null)
     container = (!params.enable_conda ? "${params.depot_url}/fastqc:0.11.7--4" : null)
@@ -89,8 +95,9 @@ process {
     container = (!params.enable_conda ? "xaratustrah/pdftools" : null)
   }
 
-  //////// Multi-tools containers
 
+  //////// Multi-tools containers
+  
   // bowtie2=2.4.4,samtools=1.13    
   withLabel:bowtie2_samtools {
     conda     = (params.enable_conda ? "bioconda::bowtie2=2.4.4 bioconda::samtools=1.13" : null)

--- a/scripts/download/download.nf
+++ b/scripts/download/download.nf
@@ -1,68 +1,70 @@
 
 
-process download_test_datasets {
-  tag params.species + " " + params.figshare_version
+
+Files_to_download = Channel
+  .from(  
+    [  
+      ['test_dataset',  params.test_datasets, params.test_dataset_file, params.test_dataset_md5sum],
+      ['references',    params.references,    params.references_file,   params.references_md5sum]
+    ]
+  )
+  .filter{ it[1] == true}
+  .map{ it[0, 2, 3] }
+  // .view()
+  .set{ Files_to_download_1 }
+
+process download_files {
+  tag "${params.species} ${params.figshare_version} ${file_type}"
+
+  label "gnu_wget"
+
+  input:
+    set file_type, figshare_file, true_md5sum from Files_to_download_1
+
+  output:
+    set file_type, "${params.species}_${file_type}_checked.tar.gz" into Files_to_extract
+    
+  script:
+    def figshare_path = "https://ndownloader.figshare.com/files"
+    def local_file    = "${params.species}_${file_type}.tar.gz"
+    def local_file_1  = "${params.species}_${file_type}_checked.tar.gz"
+    
+    """
+    wget ${figshare_path}/${figshare_file} -O ${local_file}
+    local_md5sum=\$(md5sum ${local_file} | awk '{print \$1}')
+    
+    if [[ "\$local_md5sum" == "${true_md5sum}" ]] ; then
+      mv ${local_file} ${local_file_1}
+    else
+      echo "md5sum is wrong for file ${local_file}"
+    fi
+    """
+
+}
+
+
+process extract_files {
+  tag "${params.species} ${params.figshare_version} ${file_type}"
 
   label "skewer_pigz"
 
   publishDir path: "${launchDir}", mode: params.pub_mode
 
-  when: params.test_datasets
-
   input:
+    set file_type, downloaded_file from Files_to_extract
 
   output:
-    set file('data/'), file('parameters/'), file('design/')
-    
+      set file('data/'), file('parameters/'), file('design/'), 
+          file(params.species) optional true
+
   script:
-    def figshare_path = "https://ndownloader.figshare.com/files"
-    def local_file    = "${params.species}_test_dataset.tar.gz"
-    
     """
-    wget ${figshare_path}/${params.test_dataset_file} -O ${local_file}
-    local_md5sum=\$(md5sum ${local_file} | awk '{print \$1}')
-    
-    if [[ "\$local_md5sum" == "${params.test_dataset_md5sum}" ]] ; then
-      pigz --decompress --keep --recursive --stdout --processes ${params.threads} ${local_file} | tar -xvf -
-    else
-      echo "md5sum is wrong for file ${local_file}"
-    fi
+    pigz --decompress --keep --recursive --stdout \
+      --processes ${params.threads} ${downloaded_file} | tar -xvf -
     """
 
 }
 
 // tar --use-compress-program="pigz -p ${params.threads} -k -r" -xvf ${local_file} => the pigz option is not avaialble in busybox's tar
 // pigz -d -k -r -c -p 3 $local_file | tar -xvf - // same command with abbreviations
-
-process download_references {
-  tag params.species + " " + params.figshare_version
-
-  label "skewer_pigz"
-
-  publishDir path: "${params.references_dir}", mode: params.pub_mode
-
-  when: params.references
-
-  input:
-
-  output:
-    file(params.species)
-  
-  script:
-    def figshare_path = "https://ndownloader.figshare.com/files"
-    def local_file    = "${params.species}_references.tar.gz"
-    
-    """
-    wget ${figshare_path}/${params.references_file} -O ${local_file}
-    local_md5sum=\$(md5sum ${local_file} | awk '{print \$1}')
-    
-    if [[ "\$local_md5sum" == "${params.references_md5sum}" ]] ; then
-      pigz --decompress --keep --recursive --stdout --processes ${params.threads} ${local_file} | tar -xvf -
-    else
-      echo "md5sum is wrong for file ${local_file}"
-    fi
-    """
-
-}
-
 


### PR DESCRIPTION
Fixing a new bug: the simple busybox wget cannot download the figshare files anymore. I resolved the issue by splitting the downloading and extracting steps in the downloading script, which allowed to use the single-tool BioContainer gnu-wget.